### PR TITLE
feat(misc): add reset-local-database to docker-compose #35

### DIFF
--- a/database/docker-entrypoint-initdb.d/setup.sh
+++ b/database/docker-entrypoint-initdb.d/setup.sh
@@ -1,0 +1,2 @@
+cd /database/
+psql -U postgres --quiet -f setup.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   postgres:
-    image: postgres:14.5
+    image: postgres:14
     restart: always
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
@@ -10,6 +10,7 @@ services:
       - "5432:5432"
     volumes:
       - ./database/:/database/
+      - ./database/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d/
   api:
     build: api/
     restart: always


### PR DESCRIPTION
Permet de faire un reset-local-database automatiquement au lancement du container (plus besoin de le faire apres)