### PR TITLE
Fix scroll historique et cleaning

### DIFF
--- a/api/src/dtos/profile.dto.ts
+++ b/api/src/dtos/profile.dto.ts
@@ -5,7 +5,6 @@ export interface UserDTO {
     nickname: string;
     avatar: string;
     current_status: string;
-    friends: string[];
     two_factor_enabled: boolean;
     two_factor_secret: string,
 }

--- a/api/src/entities/user.entity.ts
+++ b/api/src/entities/user.entity.ts
@@ -84,9 +84,4 @@ export class Users {
         nullable: false
     })
         current_status: string;
-
-    @Column('text', {
-        nullable: true
-    })
-        friends: string[];
 }

--- a/api/src/friendrequest/friendrequest.controller.ts
+++ b/api/src/friendrequest/friendrequest.controller.ts
@@ -6,31 +6,31 @@ import { FriendRequestService } from "src/services/friend_request.service";
 @Controller('friends')
 @Injectable()
 export class FriendRequestController {
-    constructor(private userService: FriendRequestService, @Inject("PG_CONNECTION") private db: any) {}
+    constructor(private friendRequestService: FriendRequestService, @Inject("PG_CONNECTION") private db: any) {}
 
     @Get('/requests/sent')
     getSentRequestsAction(@UserConnected() user: Users): Promise<any> {
-        return this.userService.getSentRequests(user);
+        return this.friendRequestService.getSentRequests(user);
     }
 
     @Get('/requests/:user')
     getFriendshipStatusAction(@Param('user') otherUser: string, @UserConnected() user: Users): Promise<any> {
-        return this.userService.getFriendshipStatus(otherUser, user);
+        return this.friendRequestService.getFriendshipStatus(otherUser, user);
     }
 
     @Post('/sendrequest/:friend')
     sendFriendRequestAction(@Param('friend') friend: string, @Body() body: { nickname: string }): Promise<void> {
-        return this.userService.sendFriendRequest(friend, body.nickname);
+        return this.friendRequestService.sendFriendRequest(friend, body.nickname);
     }
 
     @Get('/requests')
     getReceivedFriendRequestsAction(@UserConnected() user: Users): Promise<any> {
-        return this.userService.getReceivedFriendRequests(user);
+        return this.friendRequestService.getReceivedFriendRequests(user);
     }
 
     @Post('/requests/:user/accept')
     acceptDeclineFriendRequestAction(@Param('user') otherUser: string, @Body() body: { nickname: string, accept: boolean }): Promise<void> {
-        return this.userService.acceptDeclineFriendRequest(otherUser, body.nickname, body.accept);
+        return this.friendRequestService.acceptDeclineFriendRequest(otherUser, body.nickname, body.accept);
     }
 
     @Get('/blocked/:user_id/:user_id_friend')

--- a/api/src/services/user.service.ts
+++ b/api/src/services/user.service.ts
@@ -79,7 +79,6 @@ export class UserService {
             nickname: user.nickname,
             avatar: user.avatar,
             current_status: user.current_status,
-            friends: user.friends,
             two_factor_enabled: user.two_factor_enabled,
             two_factor_secret: user.two_factor_secret,
         };
@@ -96,7 +95,6 @@ export class UserService {
             nickname: user.nickname,
             avatar: user.avatar,
             current_status: user.current_status,
-            friends: user.friends,
             two_factor_enabled: user.two_factor_enabled,
             two_factor_secret: user.two_factor_secret,
         };
@@ -120,18 +118,5 @@ export class UserService {
         });
         user.current_status = current_status;
         await this.userRepository.save(user);
-    }
-
-    async addFriend(friend: string, nickname: string): Promise<void> {
-        const user = await this.userRepository.findOneBy({
-            nickname: nickname
-        });
-        if (!user.friends) {
-            user.friends = [];
-        }
-        if (user.friends.indexOf(friend) == -1) {
-            user.friends.push(friend);
-            await this.userRepository.save(user);
-        }
     }
 }

--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -45,11 +45,6 @@ export class UsersController {
             });
     }
 
-    @Post('/add/:friend')
-    addFriendAction(@Param('friend') friend: string, @Body() body: { nickname: string }): Promise<void> {
-        return this.userService.addFriend(friend, body.nickname);
-    }
-
     @Post('/toggle_two_factor')
     async toggleTwoFactor(@Body() body: { twoFactor:boolean, id_42:number }): Promise<UserDTO> {
         await this.db.query(`UPDATE users SET two_factor_enabled='${body.twoFactor}' WHERE id_42='${body.id_42}'`);
@@ -141,7 +136,6 @@ export class UsersController {
             nickname: req.rows[0].nickname,
             avatar: req.rows[0].avatar,
             current_status: req.rows[0].current_status,
-            friends: req.rows[0].friends,
             two_factor_enabled: req.rows[0].two_factor_enabled,
             two_factor_secret: req.rows[0].two_factor_secret,
         });

--- a/database/tables.sql
+++ b/database/tables.sql
@@ -30,8 +30,7 @@ CREATE TABLE IF NOT EXISTS public.users(
     token                           UUID DEFAULT uuid_generate_v4() NOT NULL,
     created_at                      DATE DEFAULT NULL,
     avatar                          VARCHAR(255) NOT NULL,
-    current_status                  public.current_status_enum DEFAULT 'offline',
-    friends                         TEXT[] DEFAULT NULL
+    current_status                  public.current_status_enum DEFAULT 'offline'
 );
 
 CREATE TABLE IF NOT EXISTS public.history(

--- a/webapp/src/helpers/Users.tsx
+++ b/webapp/src/helpers/Users.tsx
@@ -84,18 +84,6 @@ const updateStatus = async(nickname: string, current_status: string): Promise<an
     }
 };
 
-const addFriend = async(friend: string, nickname: string): Promise<any> => {
-    try {
-        const res = await axios.post(`${Config.Api.url}/users/add/${friend}`, {
-            nickname: nickname
-        });
-        return (res.data);
-    } catch (e) {
-        console.error(e);
-        return (null);
-    }
-};
-
 const checkNickname = async (nickname:string): Promise<boolean | undefined> => {
     try {
         const req = await axios.post(`${Config.Api.url}/users/checkNickname`, {
@@ -195,7 +183,6 @@ const Users = {
     login_with_email,
     getUser,
     updateStatus,
-    addFriend,
     changeUserData,
     checkNickname,
     checkEmail,

--- a/webapp/src/interfaces/user.tsx
+++ b/webapp/src/interfaces/user.tsx
@@ -8,6 +8,5 @@ export interface User {
     avatar: string,
     user_id: string,
     token: string,
-    current_status: string,
-    friends: string[]
+    current_status: string
 }

--- a/webapp/src/pages/Friends/FriendSearch.tsx
+++ b/webapp/src/pages/Friends/FriendSearch.tsx
@@ -31,7 +31,6 @@ const FriendSearch = () => {
         nickname: '',
         avatar: '',
         current_status: '',
-        friends: [''],
         id_42: 0,
     });
 

--- a/webapp/src/pages/Profile/Profile.scss
+++ b/webapp/src/pages/Profile/Profile.scss
@@ -34,7 +34,4 @@
 #statistics {
     position: relative;
     bottom: 6rem;
-    transform: scale(0.8);
-    margin-left: 10%;
-    max-width: 80%
 }

--- a/webapp/src/pages/Profile/Profile.tsx
+++ b/webapp/src/pages/Profile/Profile.tsx
@@ -18,7 +18,6 @@ const Profile = () => {
         nickname: '',
         avatar: '',
         current_status: '',
-        friends: [''],
         id: '',
     });
     const [, forceUpdate] = useReducer(x => x + 1, 0);


### PR DESCRIPTION
Le problème de scroll dans l'historique venait du `transform: scale(0.8)` qui était utilisé pour réduire la taille de la div. Je l'ai enlevé et les stats de l'utilisateur sont du coup un peu plus grandes. 
Un peu de refactor en enlevant le tableau de friends dans la table user et la fonction `addFriend` qui ne servaient plus puisqu'on utilise la table `FriendRequest` pour gérer ce qui concerne les amis. J'ai aussi fait quelques changements de noms dans le service `friendRequest` car ça ne faisait pas vraiment sens.