### PR TITLE
feat(api, webapp, db): replay mode, forfait if disconnected

### DIFF
--- a/api/src/services/live.service.ts
+++ b/api/src/services/live.service.ts
@@ -20,7 +20,6 @@ export class LiveService {
     }
 
     async cancelLive(id_one:number): Promise<null> {
-        console.log(`id one correspond to ${id_one}`);
         await this.db.query(`DELETE FROM public.live WHERE id_one='${id_one}'`);
         return (null);
     }

--- a/api/src/socket.gateway.ts
+++ b/api/src/socket.gateway.ts
@@ -40,6 +40,31 @@ export class SocketGateway {
         });
     }
 
+    @SubscribeMessage('endgame')
+    announceEndgame(@MessageBody() message: { data: { target: string, endgame:number } }): void {
+        this.server.emit(message.data.target + 'endgame', {
+            endgame:message.data?.endgame,
+        });
+    }
+
+    @SubscribeMessage('forfait')
+    announceForfait(@MessageBody() message: { data: { target: string, forfait:boolean } }): void {
+        this.server.emit(message.data.target + 'forfait', {
+            forfait:message.data?.forfait,
+        });
+    }
+
+    @SubscribeMessage('replay')
+    announceReplay(@MessageBody() message: { data: { target: string, incoming_id:number, incoming_nickname:string, nickname:string, cancel:boolean, confirmation:boolean } }): void {
+        this.server.emit(message.data.target + 'replay', {
+            incoming_id:message.data?.incoming_id,
+            incoming_nickname:message.data?.incoming_nickname,
+            nickname:message.data?.nickname,
+            cancel:message.data?.cancel,
+            confirmation:message.data?.confirmation,
+        });
+    }
+
     @SubscribeMessage('score')
     updateScore(@MessageBody() message: { data: { target: string, player: number, computer: number } }): void {
         this.server.emit(message.data.target + 'score', {

--- a/webapp/src/helpers/Live.tsx
+++ b/webapp/src/helpers/Live.tsx
@@ -29,7 +29,6 @@ const liveRequest = async (): Promise<LiveRequest[] | undefined> => {
 
 const liveCancel = async (id_one:number): Promise<null> => {
     try {
-        console.log(`the id helper is ${id_one}`);
         await axios.post(`${Config.Api.url}/live/cancel`, {
             id_one: id_one,
         });

--- a/webapp/src/pages/Bonus/Bonus.tsx
+++ b/webapp/src/pages/Bonus/Bonus.tsx
@@ -4,6 +4,7 @@ import { Box, Button, Card, CardContent, Toolbar, Typography } from '@mui/materi
 import { useLocation } from "react-router-dom";
 import { CountdownCircleTimer } from 'react-countdown-circle-timer';
 import "./styles.css";
+import Helpers from '../../helpers/Helpers';
 
 const Bonus = () => {
 
@@ -68,12 +69,16 @@ const Bonus = () => {
     const [end, setEnd] = useState<boolean>(false);
     const location = useLocation();
 
+    const properQuit = async () => {
+        if (location?.state?.player === 1) await Helpers.Live.liveCancel(location?.state?.my_id);
+    };
+
     return (
         <Fragment>
                 	{
                     	end?
                     <>
-                        <Button href="/play/matchmaking">
+                        <Button href="/play/matchmaking" onClick={properQuit}>
                                     Exit
                         </Button>
                         <Pong my_id={location?.state?.my_id} opp_id={location?.state?.opp_id} nickname={location?.state?.nickname} player={location?.state?.player} opp_nickname={location?.state?.opp_nickname}/>

--- a/webapp/src/pages/Bonus/components/Ball.js
+++ b/webapp/src/pages/Bonus/components/Ball.js
@@ -138,16 +138,13 @@ export default class Ball {
         }
         if (power === 0)
         {
-            // console.log('no speed powerups');
             this.velocity_toleft += (VELOCITY_INCREASE * delta);
             this.velocity_toright += (VELOCITY_INCREASE * delta);
         }
         else if (power === 1)
             ;
-            // console.log('no increase on both');
         else if (power === 2)
         {
-            // console.log('double on both');
             this.velocity_toleft += (VELOCITY_INCREASE * delta) * 2;
             this.velocity_toright += (VELOCITY_INCREASE * delta) * 2;
         }
@@ -157,93 +154,24 @@ export default class Ball {
             this.velocity_toright += VELOCITY_INCREASE * delta;
         else if (power === 5)
         {
-            // console.log('double to right');
             this.velocity_toleft += VELOCITY_INCREASE * delta;
             this.velocity_toright += (VELOCITY_INCREASE * delta) * 2;
         }
         else if (power === 6)
         {
-            // console.log('increase normal to right');
             this.velocity_toright += (VELOCITY_INCREASE * delta);
         }
         else if (power === 7)
         {
-            // console.log('double to left');
             this.velocity_toleft += VELOCITY_INCREASE * delta * 2;
             this.velocity_toright += (VELOCITY_INCREASE * delta);
         }
         else if (power === 8)
         {
-            // console.log('increase normal to left');
             this.velocity_toleft += VELOCITY_INCREASE * delta;
         }
     }
 }
-
-// update(delta, paddleRects, power){
-//     if (this.direction.x > 0)
-//     {
-//         this.x += this.direction.x * this.velocity_toright * delta;
-//         this.y += this.direction.y * this.velocity_toright * delta;
-//     }
-//     else
-//     {
-//         this.x += this.direction.x * this.velocity_toleft * delta;
-//         this.y += this.direction.y * this.velocity_toleft * delta;
-//     }
-//     const rect = this.rect();
-//     if (rect.bottom >= window.innerHeight || rect.top <= 60) {
-//         this.direction.y *= -1;
-//     }
-//     if (paddleRects.some(r => isCollision(r, rect))){
-//         this.direction.x *= -1;
-//     }
-//     if (power === 0)
-//     {
-//         console.log('no speed powerups');
-//         this.velocity_toleft += (VELOCITY_INCREASE * delta);
-//         this.velocity_toright += (VELOCITY_INCREASE * delta);
-//     }
-//     else if (power === 1)
-//         console.log('no increase on both');
-//     else if (power === 2)
-//     {
-//         console.log('double on both');
-//         this.velocity_toleft += (VELOCITY_INCREASE * delta) * 2;
-//         this.velocity_toright += (VELOCITY_INCREASE * delta) * 2;
-//     }
-//     else if (power === 3)
-//         this.velocity_toleft += VELOCITY_INCREASE * delta;
-//     else if (power == 4)
-//         this.velocity_toright += VELOCITY_INCREASE * delta;
-//     else if (power === 5)
-//     {
-//         console.log('double to right');
-//         this.velocity_toleft += VELOCITY_INCREASE * delta;
-//         this.velocity_toright += (VELOCITY_INCREASE * delta) * 2;
-//     }
-//     else if (power === 6)
-//     {
-//         console.log('increase normal to right');
-//         this.velocity_toright += (VELOCITY_INCREASE * delta);
-//     }
-//     else if (power === 7)
-//     {
-//         console.log('double to left');
-//         this.velocity_toleft += VELOCITY_INCREASE * delta * 2;
-//         this.velocity_toright += (VELOCITY_INCREASE * delta);
-//     }
-//     else if (power === 8)
-//     {
-//         console.log('increase normal to left');
-//         this.velocity_toleft += VELOCITY_INCREASE * delta;
-//     }
-// }
-// };
-
-// function isCollision(rect1, rect2){
-//     return (rect1.left <= rect2.right && rect1.right >= rect2.left && rect1.top <= rect2.bottom && rect1.bottom >= rect2.top);
-// }
 
 function randomNumberBetween(min, max) {
     return Math.random() * (max-min) + min;

--- a/webapp/src/pages/Bonus/components/Pong.tsx
+++ b/webapp/src/pages/Bonus/components/Pong.tsx
@@ -1,18 +1,20 @@
 import { useEffect, useState } from "react";
 
-import './Pong.scss';
+import "./Pong.scss";
 
-import Ball from './Ball.js';
-import Paddle from './Paddle.js';
+import Ball from "./Ball.js";
+import Paddle from "./Paddle.js";
 import React from "react";
 import { End } from "./End";
-import { io } from 'socket.io-client';
+import { io } from "socket.io-client";
 
-import Helpers from '../../../helpers/Helpers';
+import Helpers from "../../../helpers/Helpers";
 import Power from "./Power";
+import { useNavigate } from "react-router-dom";
 
+let renderStop: number = 0;
 let lastTime: any = null;
-let ball:any = null;
+let ball: any = null;
 let playerPaddle: any = null;
 let computerPaddle: any = null;
 let socket_position: any = null;
@@ -25,46 +27,49 @@ let collision_tmp = false;
 let collision_power_tmp = false;
 let unique_match = 0;
 
-let power:any = null;
+let power: any = null;
 let playerPower: any = null;
 let computerPower: any = null;
 let playerTime: number = 0;
 let computerTime: number = 0;
 
-const Pong = (props: {my_id: number, opp_id: number, nickname: string, player:number, opp_nickname: string}) => {
+let forfait: boolean = false;
 
-    const socket = io('http://localhost:5000', { transports: ['websocket'] });
+const Pong = (props: {
+    my_id: number;
+    opp_id: number;
+    nickname: string;
+    player: number;
+    opp_nickname: string;
+}) => {
+    const socket = io("http://localhost:5000", { transports: ["websocket"] });
+    const navigate = useNavigate();
 
-    const poweringUp = (side:number) => {
+    const poweringUp = (side: number) => {
         const random = Math.floor(Math.random() * 10);
-        if (random < 5)
-        {
+        if (random < 5) {
+            if (side === 1) playerPower.textContent = "no speed increase";
+            else computerPower.textContent = "no speed increase";
+        } else if (random < 7) {
+            if (side === 1) playerPower.textContent = "immunity";
+            else computerPower.textContent = "immunity";
+        } else {
             if (side === 1)
-                playerPower.textContent = 'no speed increase';
-            else
-                computerPower.textContent = 'no speed increase';
-        }
-        else if (random < 7)
-        {
-            if (side === 1)
-                playerPower.textContent = 'immunity';
-            else
-                computerPower.textContent = 'immunity';
-        }
-        else
-        {
-            if (side === 1)
-                playerPower.textContent = 'opponent double speed increase';
-            else
-                computerPower.textContent = 'opponent double speed increase';
+                playerPower.textContent = "opponent double speed increase";
+            else computerPower.textContent = "opponent double speed increase";
         }
     };
 
     const [user, setUser] = useState({
         id_42: 0,
-        email: '',
-        nickname: '',
-        avatar: '',
+        email: "",
+        nickname: "",
+        avatar: "",
+    });
+
+    window.addEventListener("beforeunload", async () => {
+        if (props.player === 1) await Helpers.Live.liveCancel(props.my_id);
+        else await Helpers.Live.liveCancel(props.opp_id);
     });
 
     useEffect(() => {
@@ -73,95 +78,165 @@ const Pong = (props: {my_id: number, opp_id: number, nickname: string, player:nu
 
     const [end, setEnd] = useState<boolean>(false);
 
-    const updating_ball = (delta: number, collision:number) => {
-        if (playerPower.textContent === 'no speed increase' && computerPower.textContent === 'no speed increase')
-            ball.update(delta, [playerPaddle.rect(), computerPaddle.rect()], collision, 1);
-        else if (playerPower.textContent === 'opponent double speed increase' && computerPower.textContent === 'opponent double speed increase')
-            ball.update(delta, [playerPaddle.rect(), computerPaddle.rect()], collision, 2);
-        else if (playerPower.textContent === 'no speed increase' && computerPower.textContent === 'opponent double speed increase')
-            ball.update(delta, [playerPaddle.rect(), computerPaddle.rect()], collision, 3);
-        else if (playerPower.textContent === 'opponent double speed increase' && computerPower.textContent === 'no speed increase')
-            ball.update(delta, [playerPaddle.rect(), computerPaddle.rect()], collision, 4);
-        else if (playerPower.textContent === 'opponent double speed increase')
-            ball.update(delta, [playerPaddle.rect(), computerPaddle.rect()], collision, 5);
-        else if (playerPower.textContent === 'no speed increase')
-            ball.update(delta, [playerPaddle.rect(), computerPaddle.rect()], collision, 6);
-        else if (computerPower.textContent === 'opponent double speed increase')
-            ball.update(delta, [playerPaddle.rect(), computerPaddle.rect()], collision, 7);
-        else if (computerPower.textContent === 'no speed increase')
-            ball.update(delta, [playerPaddle.rect(), computerPaddle.rect()], collision, 8);
+    const updating_ball = (delta: number, collision: number) => {
+        if (
+            playerPower.textContent === "no speed increase" &&
+            computerPower.textContent === "no speed increase"
+        )
+            ball.update(
+                delta,
+                [playerPaddle.rect(), computerPaddle.rect()],
+                collision,
+                1
+            );
+        else if (
+            playerPower.textContent === "opponent double speed increase" &&
+            computerPower.textContent === "opponent double speed increase"
+        )
+            ball.update(
+                delta,
+                [playerPaddle.rect(), computerPaddle.rect()],
+                collision,
+                2
+            );
+        else if (
+            playerPower.textContent === "no speed increase" &&
+            computerPower.textContent === "opponent double speed increase"
+        )
+            ball.update(
+                delta,
+                [playerPaddle.rect(), computerPaddle.rect()],
+                collision,
+                3
+            );
+        else if (
+            playerPower.textContent === "opponent double speed increase" &&
+            computerPower.textContent === "no speed increase"
+        )
+            ball.update(
+                delta,
+                [playerPaddle.rect(), computerPaddle.rect()],
+                collision,
+                4
+            );
+        else if (playerPower.textContent === "opponent double speed increase")
+            ball.update(
+                delta,
+                [playerPaddle.rect(), computerPaddle.rect()],
+                collision,
+                5
+            );
+        else if (playerPower.textContent === "no speed increase")
+            ball.update(
+                delta,
+                [playerPaddle.rect(), computerPaddle.rect()],
+                collision,
+                6
+            );
+        else if (computerPower.textContent === "opponent double speed increase")
+            ball.update(
+                delta,
+                [playerPaddle.rect(), computerPaddle.rect()],
+                collision,
+                7
+            );
+        else if (computerPower.textContent === "no speed increase")
+            ball.update(
+                delta,
+                [playerPaddle.rect(), computerPaddle.rect()],
+                collision,
+                8
+            );
         else
-            ball.update(delta, [playerPaddle.rect(), computerPaddle.rect()], collision, 0);
+            ball.update(
+                delta,
+                [playerPaddle.rect(), computerPaddle.rect()],
+                collision,
+                0
+            );
     };
 
-    const timeoutPowerUps = (time:number) => {
-        if (time > playerTime + 8000)
-            playerPower.textContent = 'no powerups';
+    const timeoutPowerUps = (time: number) => {
+        if (time > playerTime + 8000) playerPower.textContent = "no powerups";
         if (time > computerTime + 8000)
-            computerPower.textContent = 'no powerups';
+            computerPower.textContent = "no powerups";
     };
 
-    const checkPowerUps = (time:number) => {
-        if (isCollision(playerPaddle.rect(), power.rect()))
-        {
-            if (playerPower.textContent === 'no powerups')
-            {
+    const checkPowerUps = (time: number) => {
+        if (isCollision(playerPaddle.rect(), power.rect())) {
+            if (playerPower.textContent === "no powerups") {
                 poweringUp(1);
                 playerTime = time;
             }
         }
-        if (isCollision(computerPaddle.rect(), power.rect()))
-        {
-            if (computerPower.textContent === 'no powerups')
-            {
+        if (isCollision(computerPaddle.rect(), power.rect())) {
+            if (computerPower.textContent === "no powerups") {
                 poweringUp(2);
                 computerTime = time;
             }
         }
     };
 
-    const updatingBall = (delta:number) => {
-        if ((isCollision(playerPaddle.rect(), ball.rect()) || isCollision(computerPaddle.rect(), ball.rect())) && collision_tmp === false)
-        {
+    const updatingBall = (delta: number) => {
+        if (
+            (isCollision(playerPaddle.rect(), ball.rect()) ||
+                isCollision(computerPaddle.rect(), ball.rect())) &&
+            collision_tmp === false
+        ) {
             if (isCollision(playerPaddle.rect(), ball.rect()))
                 playerPongs = playerPongs + 1;
             if (isCollision(computerPaddle.rect(), ball.rect()))
                 computerPongs = computerPongs + 1;
             updating_ball(delta, 1);
             collision_tmp = true;
-        }
-        else
-        {
+        } else {
             updating_ball(delta, 0);
             collision_tmp = false;
         }
     };
 
     const updatingPower = (delta: number) => {
-        if ((power.rect().right >= window.innerWidth || power.rect().left <= 0) && collision_power_tmp === false)
-        {
+        if (
+            (power.rect().right >= window.innerWidth ||
+                power.rect().left <= 0) &&
+            collision_power_tmp === false
+        ) {
             power.update(delta, 1);
             collision_power_tmp = true;
-        }
-        else
-        {
+        } else {
             power.update(delta, 0);
             collision_power_tmp = false;
         }
     };
 
     function update(time: any) {
-        if (stop)
+        if (forfait === true)
+        {
+            socket.emit("forfait", {
+                data: {
+                    target: props.opp_id.toString(),
+                },
+            });
             return;
-        if (lastTime != null){
+        }
+        renderStop += 1;
+        if (renderStop > 600) {
+            forfait = true;
+            navigate("/play/forfait", {
+                state: {
+                    opp_nickname: props.opp_nickname,
+                },
+            });
+        }
+        if (stop) return;
+        if (lastTime != null) {
             const delta = time - lastTime;
-            if (props.player === 1)
-            {
+            if (props.player === 1) {
                 updatingBall(delta);
                 checkPowerUps(time);
                 timeoutPowerUps(time);
                 updatingPower(delta);
-                socket.emit('ball', {
+                socket.emit("ball", {
                     data: {
                         target: props.opp_id,
                         x: ball.get_x(),
@@ -170,150 +245,274 @@ const Pong = (props: {my_id: number, opp_id: number, nickname: string, player:nu
                         p_y: power.get_y(),
                         p_l: playerPower.textContent,
                         p_r: computerPower.textContent,
-                    }
+                    },
                 });
             }
             computerPaddle.position = socket_position;
-            if (isLose()){
+            if (isLose()) {
                 handleLose();
             }
-            const hue = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--hue'));
-            document.documentElement.style.setProperty('--hue', (hue + delta * 0.01).toString());
+            const hue = parseFloat(
+                getComputedStyle(document.documentElement).getPropertyValue(
+                    "--hue"
+                )
+            );
+            document.documentElement.style.setProperty(
+                "--hue",
+                (hue + delta * 0.01).toString()
+            );
         }
         lastTime = time;
         window.requestAnimationFrame(update);
     }
 
-    function isCollision(rect1:any, rect2:any){
-        return (rect1.left <= rect2.right && rect1.right >= rect2.left && rect1.top <= rect2.bottom && rect1.bottom >= rect2.top);
+    function isCollision(rect1: any, rect2: any) {
+        return (
+            rect1.left <= rect2.right &&
+            rect1.right >= rect2.left &&
+            rect1.top <= rect2.bottom &&
+            rect1.bottom >= rect2.top
+        );
     }
 
-    function isLose(){
+    function isLose() {
         const rect = ball.rect();
-        return (rect.right >= window.innerWidth || rect.left <= 0);
+        return rect.right >= window.innerWidth || rect.left <= 0;
     }
 
-    async function handleLose(){
-        if (stop)
-            return;
+    async function handleLose() {
+        if (stop) return;
         const rect = ball.rect();
-        if (rect.right >= window.innerWidth){
-            if (props.player === 2 && computerPower.textContent === 'immunity')
-            {
+        if (rect.right >= window.innerWidth) {
+            if (
+                props.player === 2 &&
+                computerPower.textContent === "immunity"
+            ) {
                 ball.invert();
-                computerPower.textContent = '';
-                return ;
+                computerPower.textContent = "";
+                return;
             }
-            playerScoreElem.textContent = parseInt(playerScoreElem.textContent) + 1;
+            playerScoreElem.textContent =
+                parseInt(playerScoreElem.textContent) + 1;
         } else {
-            if (props.player === 1 && playerPower.textContent === 'immunity')
-            {
+            if (props.player === 1 && playerPower.textContent === "immunity") {
                 ball.invert();
-                playerPower.textContent = '';
-                return ;
+                playerPower.textContent = "";
+                return;
             }
-            computerScoreElem.textContent = parseInt(computerScoreElem.textContent) + 1;
+            computerScoreElem.textContent =
+                parseInt(computerScoreElem.textContent) + 1;
         }
-        if (parseInt(computerScoreElem.textContent) === 1 || parseInt(playerScoreElem.textContent) === 1)
-        {
-            await Helpers.History.add_match(parseInt(playerScoreElem.textContent), playerPongs, parseInt(computerScoreElem.textContent), props.opp_nickname);
-            if (props.player === 1)
-                await Helpers.Live.liveCancel(props.my_id);
+        if (
+            parseInt(computerScoreElem.textContent) === 1 ||
+            parseInt(playerScoreElem.textContent) === 1
+        ) {
+            await Helpers.History.add_match(
+                parseInt(playerScoreElem.textContent),
+                playerPongs,
+                parseInt(computerScoreElem.textContent),
+                props.opp_nickname
+            );
+            if (props.player === 1) await Helpers.Live.liveCancel(props.my_id);
+            if (props.player == 1) {
+                const score_uno = parseInt(playerScoreElem.textContent);
+                const score_doss = parseInt(computerScoreElem.textContent);
+                playerScoreElem.textContent = 0;
+                computerScoreElem.textContent = 0;
+                if (forfait !== true)
+                {
+                    socket.emit("endgame", {
+                        data: {
+                            target: props.opp_id.toString(),
+                            endgame: 1,
+                        },
+                    });
+                    navigate("/play/endgame", {
+                        state: {
+                            id_one: props.my_id,
+                            id_two: props.opp_id,
+                            player_one: props.nickname,
+                            player_two: props.opp_nickname,
+                            score_one: score_uno,
+                            score_two: score_doss,
+                            is_one: 1,
+                        },
+                    });
+                }
+            }
             stop = true;
             setEnd(true);
         }
-        socket.emit('score', {
+        socket.emit("score", {
             data: {
                 target: props.opp_id.toString(),
                 player: parseInt(playerScoreElem.textContent),
                 computer: parseInt(computerScoreElem.textContent),
-            }
+            },
         });
         ball.reset();
         power.reset();
-        computerPower.textContent = 'no powerups';
-        playerPower.textContent = 'no powerups';
+        computerPower.textContent = "no powerups";
+        playerPower.textContent = "no powerups";
         playerTime -= 4000;
         computerTime -= 4000;
         computerPaddle.reset();
     }
 
-    document.addEventListener('mousemove', e => {
+    document.addEventListener("mousemove", (e) => {
         playerPaddle.position = (e.y / window.innerHeight) * 100;
-        socket.emit('paddle', {
+        socket.emit("paddle", {
             data: {
                 target: props.opp_id.toString(),
                 position: playerPaddle.position,
-            }
+            },
         });
     });
 
-    socket.on(user.id_42.toString() + 'paddle', (data: { position: number, }) => {
-        socket_position = data.position;
+    socket.on(
+        user.id_42.toString() + "paddle",
+        (data: { position: number }) => {
+            if (socket_position != data.position)
+                renderStop = 0;
+            socket_position = data.position;
+        }
+    );
+
+    socket.on(user.id_42.toString() + "forfait", () => {
+        forfait = true;
+        navigate("/play/forfait", {
+            state: {
+                opp_nickname: props.opp_nickname,
+            },
+        });
     });
 
-    socket.on(user.id_42.toString() + 'score', (data: { player: number, computer: number }) => {
-        computerScoreElem.textContent = data.computer;
-        playerScoreElem.textContent = data.player;
-    });
+    socket.on(
+        user.id_42.toString() + "endgame",
+        () => {
+            navigate("/play/endgame", {
+                state: {
+                    id_one: props.opp_id,
+                    id_two: props.my_id,
+                    player_one: props.opp_nickname,
+                    player_two: props.nickname,
+                    score_one: parseInt(playerScoreElem.textContent),
+                    score_two: parseInt(computerScoreElem.textContent),
+                    is_one: 0,
+                },
+            });
+        }
+    );
 
-    socket.on(user.id_42.toString() + 'ball', (data: { x: number, y: number, p_x: number, p_y: number, p_l:string, p_r:string, }) => {
-        ball.set_x(data.x);
-        ball.set_y(data.y);
-        power.set_x(data.p_x);
-        power.set_y(data.p_y);
-        playerPower.textContent = data.p_l;
-        computerPower.textContent = data.p_r;
-    });
+    socket.on(
+        user.id_42.toString() + "score",
+        (data: { player: number; computer: number }) => {
+            computerScoreElem.textContent = data.computer;
+            playerScoreElem.textContent = data.player;
+        }
+    );
+
+    socket.on(
+        user.id_42.toString() + "ball",
+        (data: {
+            x: number;
+            y: number;
+            p_x: number;
+            p_y: number;
+            p_l: string;
+            p_r: string;
+        }) => {
+            ball.set_x(data.x);
+            ball.set_y(data.y);
+            power.set_x(data.p_x);
+            power.set_y(data.p_y);
+            playerPower.textContent = data.p_l;
+            computerPower.textContent = data.p_r;
+        }
+    );
 
     useEffect(() => {
-        if (props.player === 1 && unique_match == 0)
-        {
-            Helpers.Live.liveAdd(props.my_id, props.opp_id, props.nickname, props.opp_nickname);
+        lastTime = null;
+        ball = null;
+        playerPaddle = null;
+        computerPaddle = null;
+        socket_position = 0;
+        playerScoreElem = 0;
+        computerScoreElem = 0;
+        computerPongs = 0;
+        playerPongs = 0;
+        stop = false;
+        collision_tmp = false;
+        collision_power_tmp = false;
+        unique_match = 0;
+        power = null;
+        playerPower = null;
+        computerPower = null;
+        playerTime = 0;
+        computerTime = 0;
+        renderStop = 0;
+
+        if (props.player === 1 && unique_match == 0) {
+            Helpers.Live.liveAdd(
+                props.my_id,
+                props.opp_id,
+                props.nickname,
+                props.opp_nickname
+            );
             unique_match = 1;
         }
-        ball = new Ball(document.getElementById('ball'));
-        power = new Power(document.getElementById('power'));
-        if (props.player === 1)
-        {
-            playerPaddle = new Paddle(document.getElementById('player-paddle'));
-            computerPaddle = new Paddle(document.getElementById('computer-paddle'));
+        ball = new Ball(document.getElementById("ball"));
+        power = new Power(document.getElementById("power"));
+        if (props.player === 1) {
+            playerPaddle = new Paddle(document.getElementById("player-paddle"));
+            computerPaddle = new Paddle(
+                document.getElementById("computer-paddle")
+            );
+        } else {
+            playerPaddle = new Paddle(
+                document.getElementById("computer-paddle")
+            );
+            computerPaddle = new Paddle(
+                document.getElementById("player-paddle")
+            );
         }
-        else
-        {
-            playerPaddle = new Paddle(document.getElementById('computer-paddle'));
-            computerPaddle = new Paddle(document.getElementById('player-paddle'));
-        }
-        playerPower = document.getElementById('power-left');
-        computerPower = document.getElementById('power-right');
-        playerPower.textContent = 'no powerups';
-        computerPower.textContent = 'no powerups';
-        playerScoreElem = document.getElementById('player-score');
-        computerScoreElem = document.getElementById('computer-score');
+        playerPower = document.getElementById("power-left");
+        computerPower = document.getElementById("power-right");
+        playerPower.textContent = "no powerups";
+        computerPower.textContent = "no powerups";
+        playerScoreElem = document.getElementById("player-score");
+        computerScoreElem = document.getElementById("computer-score");
         window.requestAnimationFrame(update);
-    });
+    }, [false]);
 
     return (
-        <section id='pong-section'>
-            {end? <End scoreOne={parseInt(playerScoreElem.textContent)} scoreTwo={parseInt(computerScoreElem.textContent)} player={props.player} nickname={props.nickname} opp_nickname={props.opp_nickname} />
-                :
+        <section id="pong-section">
+            {end ? (
+                <End
+                    scoreOne={parseInt(playerScoreElem.textContent)}
+                    scoreTwo={parseInt(computerScoreElem.textContent)}
+                    player={props.player}
+                    nickname={props.nickname}
+                    opp_nickname={props.opp_nickname}
+                />
+            ) : (
                 <>
                     <div className="powerleft">
-                        <div id='power-left'>bloup</div>
+                        <div id="power-left">bloup</div>
                     </div>
                     <div className="powerright">
-                        <div id='power-right'>bloup</div>
+                        <div id="power-right">bloup</div>
                     </div>
                     <div className="score">
-                        <div id='player-score'>0</div>
-                        <div id='computer-score'>0</div>
+                        <div id="player-score">0</div>
+                        <div id="computer-score">0</div>
                     </div>
                 </>
-            }
-            <div className='ball' id='ball'></div>
-            <div className='power' id='power'></div>
-            <div className='paddle left' id='player-paddle'></div>
-            <div className='paddle right' id='computer-paddle'></div>
+            )}
+            <div className="ball" id="ball"></div>
+            <div className="power" id="power"></div>
+            <div className="paddle left" id="player-paddle"></div>
+            <div className="paddle right" id="computer-paddle"></div>
         </section>
     );
 };

--- a/webapp/src/pages/Endgame/Endgame.tsx
+++ b/webapp/src/pages/Endgame/Endgame.tsx
@@ -1,0 +1,194 @@
+import { Box, Button, CircularProgress, Typography } from "@mui/material";
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { io } from "socket.io-client";
+import CancelIcon from "@mui/icons-material/Cancel";
+
+const Endgame = () => {
+    const location = useLocation();
+    const socket = io("http://localhost:5000", { transports: ["websocket"] });
+    const navigate = useNavigate();
+
+    const [locations, setLocations] = useState({
+        my_id: 0,
+        opp_id: 0,
+        my_nickname: "",
+        opp_nickname: "",
+    });
+
+    const [waiting, setWaiting] = useState<boolean>(false);
+    const [oppWaiting, setOppWaiting] = useState<boolean>(false);
+    // let my_id = 0;
+    // let opp_id = 0;
+    // let my_nickname = "";
+    // let opp_nickname = "";
+
+    // {
+    //     // eslint-disable-next-line no-unused-expressions
+    //     data.is_one ? (my_id = data.id_one) : (my_id = data.id_two);
+    //     // eslint-disable-next-line no-unused-expressions
+    //     data.is_one ? (opp_id = data.id_two) : (opp_id = data.id_one);
+    //     // eslint-disable-next-line no-unused-expressions
+    //     data.is_one ? (my_nickname = data.player_one) : (opp_id = data.player_two);
+    //     // eslint-disable-next-line no-unused-expressions
+    //     data.is_one ? (opp_nickname = data.player_two) : (opp_nickname = data.player_one);
+    // }
+
+    useEffect(() => {
+        if (location?.state?.is_one) {
+            setLocations({
+                my_id: location?.state?.id_one,
+                opp_id: location?.state?.id_two,
+                my_nickname: location?.state?.player_one,
+                opp_nickname: location?.state?.player_two,
+            });
+        } else {
+            setLocations({
+                my_id: location?.state?.id_two,
+                opp_id: location?.state?.id_one,
+                my_nickname: location?.state?.player_two,
+                opp_nickname: location?.state?.player_one,
+            });
+        }
+    }, [false]);
+
+    const replay_on = () => {
+        if (oppWaiting) {
+            socket.emit("replay", {
+                data: {
+                    target: locations.opp_id.toString(),
+                    incoming_id: locations.my_id,
+                    incoming_nickname: locations.my_nickname,
+                    nickname: locations.opp_nickname,
+                    cancel: false,
+                    confirmation: true,
+                },
+            });
+            setWaiting(false);
+            navigate("/play/bonus", {
+                state: {
+                    my_id: locations.my_id,
+                    opp_id: locations.opp_id,
+                    opp_nickname: locations.opp_nickname,
+                    nickname: locations.my_nickname,
+                    player: 2,
+                },
+            });
+        } else {
+            setWaiting(true);
+            socket.emit("replay", {
+                data: {
+                    target: locations.opp_id.toString(),
+                    incoming_id: locations.my_id,
+                    incoming_nickname: locations.my_nickname,
+                    nickname: locations.opp_nickname,
+                    cancel: false,
+                    confirmation: false,
+                },
+            });
+        }
+    };
+
+    const replay_off = () => {
+        setWaiting(false);
+        socket.emit("replay", {
+            data: {
+                target: locations.opp_id.toString(),
+                incoming_id: locations.my_id,
+                incoming_nickname: locations.my_nickname,
+                nickname: locations.opp_nickname,
+                cancel: true,
+                confirmation: false,
+            },
+        });
+    };
+
+    socket.on(
+        locations.my_id.toString() + "replay",
+        (data: {
+            incoming_id: number;
+            incoming_nickname: string;
+            nickname: string;
+            cancel: boolean;
+            confirmation: boolean;
+        }) => {
+            if (data.confirmation) {
+                navigate("/play/bonus", {
+                    state: {
+                        my_id: locations.my_id,
+                        opp_id: locations.opp_id,
+                        opp_nickname: locations.opp_nickname,
+                        nickname: locations.my_nickname,
+                        player: 1,
+                    },
+                });
+            } else {
+                if (data.cancel) {
+                    setOppWaiting(false);
+                }
+                else {
+                    setOppWaiting(true);
+                }
+            }
+        }
+    );
+
+    return (
+        <>
+            <Typography sx={{ m: 1 }} variant="h2">
+                End Game
+            </Typography>
+            {location?.state?.score_one > location?.state?.score_two &&
+            location?.state?.is_one ? (
+                    <div>you won as player one</div>
+                ) : location?.state?.score_one < location?.state?.score_two &&
+              !location?.state?.is_one ? (
+                        <div>you won as player 2</div>
+                    ) : (
+                        <div>you lost</div>
+                    )}
+            <Button href="/play">Exit</Button>
+            {waiting ? (
+                <Box
+                    sx={{
+                        alignItems: "center",
+                        display: "flex",
+                        flexDirection: "column",
+                    }}
+                >
+                    <CircularProgress color="secondary" sx={{ mb: "50px" }} />
+                    <Typography
+                        component="h2"
+                        variant="h6"
+                        color="primary"
+                        gutterBottom
+                    >
+                        Waiting for opponent ...
+                    </Typography>
+                    <Button onClick={replay_off} color="error">
+                        <CancelIcon />
+                    </Button>
+                </Box>
+            ) : (
+                <Box
+                    sx={{
+                        alignItems: "center",
+                        display: "flex",
+                        flexDirection: "column",
+                    }}
+                >
+                    <Button
+                        onClick={replay_on}
+                        color="primary"
+                        variant="contained"
+                        sx={{ mt: "90px" }}
+                    >
+                        Find opponent
+                    </Button>
+                </Box>
+            )}
+        </>
+    );
+};
+
+export default Endgame;

--- a/webapp/src/pages/Forfait/Forfait.tsx
+++ b/webapp/src/pages/Forfait/Forfait.tsx
@@ -1,0 +1,12 @@
+// import { useLocation } from "react-router-dom";
+
+const Forfait = () => {
+
+    // const location = useLocation();
+
+    return (
+        <div>a problem occured during the match, please try again</div>
+    );
+};
+
+export default Forfait;

--- a/webapp/src/pages/Home/Home.tsx
+++ b/webapp/src/pages/Home/Home.tsx
@@ -7,9 +7,8 @@ import { useEffect } from "react";
 import Helpers from "../../helpers/Helpers";
 
 const Home = () => {
-
     useEffect(() => {
-        Helpers.Users.me().then((res:any) => console.log(res!));
+        Helpers.Users.me().then((res: any) => console.log(res!));
     }, []);
 
     return (
@@ -20,8 +19,8 @@ const Home = () => {
                         <Paper
                             sx={{
                                 p: 2,
-                                display: 'flex',
-                                flexDirection: 'column',
+                                display: "flex",
+                                flexDirection: "column",
                                 height: 220,
                             }}
                         >
@@ -32,8 +31,8 @@ const Home = () => {
                         <Paper
                             sx={{
                                 p: 2,
-                                display: 'flex',
-                                flexDirection: 'column',
+                                display: "flex",
+                                flexDirection: "column",
                                 height: 220,
                             }}
                         >
@@ -41,8 +40,14 @@ const Home = () => {
                         </Paper>
                     </Grid>
                     <Grid item xs={12}>
-                        <Paper sx={{ p: 2, display: 'flex', flexDirection: 'column' }}>
-                            <MatchHistory  />
+                        <Paper
+                            sx={{
+                                p: 2,
+                                display: "flex",
+                                flexDirection: "column",
+                            }}
+                        >
+                            <MatchHistory />
                         </Paper>
                     </Grid>
                 </Grid>

--- a/webapp/src/pages/Matchmaking/Matchmaking.tsx
+++ b/webapp/src/pages/Matchmaking/Matchmaking.tsx
@@ -31,6 +31,18 @@ const Matchmaking = () => {
             }
             else
             {
+                if (res?.result[0].id_42 === user.id_42 && res?.result.length === 1)
+                    return ;
+                else if (res?.result[0].id_42 === user.id_42)
+                {
+                    socket.emit('matchmaking', {
+                        data: {
+                            target: res?.result[1].id_42.toString(),
+                            callback: user.id_42,
+                            nickname: user.nickname,
+                        }
+                    });
+                }
                 socket.emit('matchmaking', {
                     data: {
                         target: res?.result[0].id_42.toString(),

--- a/webapp/src/pages/Spectating/components/Ball.js
+++ b/webapp/src/pages/Spectating/components/Ball.js
@@ -138,16 +138,13 @@ export default class Ball {
         }
         if (power === 0)
         {
-            // console.log('no speed powerups');
             this.velocity_toleft += (VELOCITY_INCREASE * delta);
             this.velocity_toright += (VELOCITY_INCREASE * delta);
         }
         else if (power === 1)
             ;
-            // console.log('no increase on both');
         else if (power === 2)
         {
-            // console.log('double on both');
             this.velocity_toleft += (VELOCITY_INCREASE * delta) * 2;
             this.velocity_toright += (VELOCITY_INCREASE * delta) * 2;
         }
@@ -157,93 +154,24 @@ export default class Ball {
             this.velocity_toright += VELOCITY_INCREASE * delta;
         else if (power === 5)
         {
-            // console.log('double to right');
             this.velocity_toleft += VELOCITY_INCREASE * delta;
             this.velocity_toright += (VELOCITY_INCREASE * delta) * 2;
         }
         else if (power === 6)
         {
-            // console.log('increase normal to right');
             this.velocity_toright += (VELOCITY_INCREASE * delta);
         }
         else if (power === 7)
         {
-            // console.log('double to left');
             this.velocity_toleft += VELOCITY_INCREASE * delta * 2;
             this.velocity_toright += (VELOCITY_INCREASE * delta);
         }
         else if (power === 8)
         {
-            // console.log('increase normal to left');
             this.velocity_toleft += VELOCITY_INCREASE * delta;
         }
     }
 }
-
-// update(delta, paddleRects, power){
-//     if (this.direction.x > 0)
-//     {
-//         this.x += this.direction.x * this.velocity_toright * delta;
-//         this.y += this.direction.y * this.velocity_toright * delta;
-//     }
-//     else
-//     {
-//         this.x += this.direction.x * this.velocity_toleft * delta;
-//         this.y += this.direction.y * this.velocity_toleft * delta;
-//     }
-//     const rect = this.rect();
-//     if (rect.bottom >= window.innerHeight || rect.top <= 60) {
-//         this.direction.y *= -1;
-//     }
-//     if (paddleRects.some(r => isCollision(r, rect))){
-//         this.direction.x *= -1;
-//     }
-//     if (power === 0)
-//     {
-//         console.log('no speed powerups');
-//         this.velocity_toleft += (VELOCITY_INCREASE * delta);
-//         this.velocity_toright += (VELOCITY_INCREASE * delta);
-//     }
-//     else if (power === 1)
-//         console.log('no increase on both');
-//     else if (power === 2)
-//     {
-//         console.log('double on both');
-//         this.velocity_toleft += (VELOCITY_INCREASE * delta) * 2;
-//         this.velocity_toright += (VELOCITY_INCREASE * delta) * 2;
-//     }
-//     else if (power === 3)
-//         this.velocity_toleft += VELOCITY_INCREASE * delta;
-//     else if (power == 4)
-//         this.velocity_toright += VELOCITY_INCREASE * delta;
-//     else if (power === 5)
-//     {
-//         console.log('double to right');
-//         this.velocity_toleft += VELOCITY_INCREASE * delta;
-//         this.velocity_toright += (VELOCITY_INCREASE * delta) * 2;
-//     }
-//     else if (power === 6)
-//     {
-//         console.log('increase normal to right');
-//         this.velocity_toright += (VELOCITY_INCREASE * delta);
-//     }
-//     else if (power === 7)
-//     {
-//         console.log('double to left');
-//         this.velocity_toleft += VELOCITY_INCREASE * delta * 2;
-//         this.velocity_toright += (VELOCITY_INCREASE * delta);
-//     }
-//     else if (power === 8)
-//     {
-//         console.log('increase normal to left');
-//         this.velocity_toleft += VELOCITY_INCREASE * delta;
-//     }
-// }
-// };
-
-// function isCollision(rect1, rect2){
-//     return (rect1.left <= rect2.right && rect1.right >= rect2.left && rect1.top <= rect2.bottom && rect1.bottom >= rect2.top);
-// }
 
 function randomNumberBetween(min, max) {
     return Math.random() * (max-min) + min;

--- a/webapp/src/pages/Spectating/components/SpectatePong.tsx
+++ b/webapp/src/pages/Spectating/components/SpectatePong.tsx
@@ -10,6 +10,7 @@ import { io } from "socket.io-client";
 
 import Power from "./Power";
 import { Button } from "@mui/material";
+import { useNavigate } from "react-router-dom";
 
 let lastTime: any = null;
 let ball: any = null;
@@ -30,6 +31,8 @@ let playerPower: any = null;
 let computerPower: any = null;
 let playerTime: number = 0;
 let computerTime: number = 0;
+
+let renderStop: number = 0;
 
 const SpectatePong = (props: {
     my_id: number;
@@ -61,6 +64,8 @@ const SpectatePong = (props: {
         nickname: "",
         avatar: "",
     };
+
+    const navigate = useNavigate();
 
     const [end, setEnd] = useState<boolean>(false);
 
@@ -197,6 +202,10 @@ const SpectatePong = (props: {
 
     function update(time: any) {
         if (stop) return;
+        renderStop += 1;
+        if (renderStop > 50) {
+            navigate("/play/live", {});
+        }
         if (lastTime != null) {
             const delta = time - lastTime;
             if (props.player === 1) {
@@ -204,17 +213,6 @@ const SpectatePong = (props: {
                 checkPowerUps(time);
                 timeoutPowerUps(time);
                 updatingPower(delta);
-                socket.emit("ball", {
-                    data: {
-                        target: props.opp_id,
-                        x: ball.get_x(),
-                        y: ball.get_y(), //emit also power coordinates, power ups
-                        p_x: power.get_x(),
-                        p_y: power.get_y(),
-                        p_l: playerPower.textContent,
-                        p_r: computerPower.textContent,
-                    },
-                });
             }
             computerPaddle.position = socket_position;
             playerPaddle.position = another_socket_position;
@@ -276,6 +274,7 @@ const SpectatePong = (props: {
             parseInt(computerScoreElem.textContent) === 1 ||
             parseInt(playerScoreElem.textContent) === 1
         ) {
+            navigate("/play/live", {});
             stop = true;
             setEnd(true);
         }
@@ -326,6 +325,7 @@ const SpectatePong = (props: {
             power.set_y(data.p_y);
             playerPower.textContent = data.p_l;
             computerPower.textContent = data.p_r;
+            renderStop = 0;
         }
     );
 

--- a/webapp/src/pages/Utils/NewAppBar.tsx
+++ b/webapp/src/pages/Utils/NewAppBar.tsx
@@ -40,6 +40,8 @@ import Bonus from '../Bonus/Bonus';
 import Settings from '../chat/Settings';
 import Live from '../Live/Live';
 import Spectating from '../Spectating';
+import Endgame from '../Endgame/Endgame';
+import Forfait from '../Forfait/Forfait';
 
 
 
@@ -254,6 +256,8 @@ export default function PersistentDrawerLeft() {
                     <Route path="/play/matchmaking" element={<Matchmaking/>}/>
                     <Route path="/play/live" element={<Live/>}/>
                     <Route path="/play/spectating" element={<Spectating/>}/>
+                    <Route path="/play/endgame" element={<Endgame/>}/>
+                    <Route path="/play/forfait" element={<Forfait/>}/>
                 </Routes>
             ) : (
                 <Main open={open}>
@@ -282,6 +286,8 @@ export default function PersistentDrawerLeft() {
                         <Route path="/play/matchmaking" element={<Matchmaking/>}/>
                         <Route path="/play/live" element={<Live/>}/>
                         <Route path="/play/spectating" element={<Spectating/>}/>
+                        <Route path="/play/endgame" element={<Endgame/>}/>
+                        <Route path="/play/forfait" element={<Forfait/>}/>
                     </Routes>
                 </Main>
             )}


### PR DESCRIPTION
Hello la team, pr sur le mode replay (pas obligatoire mais coherent) et sur la deconnexion de l'adversaire (close window, low latency) et sur la page de fin de match 

Pour se faire:
- Creation de differentes channels de sockets, 'endmatch', 'replay' etc 
FIN DE MATCH
- Quand fin du match il y a, l'host envoie une socket et quitte le match, l'autre joueur recoit la socket et quitte le match
REPLAY
- Sur la page de fin de partie, cliquer sur le replay envoie un demande de replay a l'autre joueur, en cas d'annulation une socket est envoye a l'autre joueur pour l'avertir
- Si le joueur replay alors qu'il a deja recu une demande de l'autre joueur, relance de la partie (le live est recree etc)
DECONNEXION
- Si le joueur ne recoit plus de signaux de l'autre joueur au bout de 2000 frames, fin de match et redirection vers la page forfait
- Live finito egalement

ps: j'ai fait le choix de ne pas ajouter dans l'historique si c'est un forfait vu que techniquement le match n'est pas fini, mais je peux le rajouter, c'est juste que c'est pas coherent parce que y'a pas de score 'forfait' dans l'historique, ca aurait ete un jeux qui va vraiment se joueur je l'aurait fait mais la je le fais pas par soucis de clarete pour eviter que des scores random soit affiches dans l'historique sur une partie forfait
on peut neanmoins le rajouter dans une autre pr si vous voulez et qu'on a le temps

ps2: le front est vraiment moche pour l'instant je le concoit, c'est pour me concentrer sur les features parce que comme je suis seul sur le jeux j'essai deja de faire un fonctionnel parfait
mais si vous etes chaud de m'aider sur le front je suis preneur, pour la page forfait, end game etc 

a toute la team 🚀🚀🚀

