### PR TITLE
refactor(webapp): all localstorage to cookies #182

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -36,6 +36,7 @@
     "socket.io-client": "^4.5.3",
     "typescript": "^4.8.4",
     "uuid": "9.0.0",
+    "universal-cookie": "4.0.4",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/webapp/src/components/menu.tsx
+++ b/webapp/src/components/menu.tsx
@@ -2,6 +2,7 @@ import { Fragment, useEffect, useState } from 'react';
 import { AppBar, Toolbar, IconButton, Typography, Button, Box } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import Helpers from '../helpers/Helpers';
+import Cookies from 'universal-cookie';
 
 const MenuComponent = () => {
     const navigate = useNavigate();
@@ -9,8 +10,15 @@ const MenuComponent = () => {
         email: '',
         nickname: ''
     });
+
+    const cookies = new Cookies();
+
     const disconnectUser = () => {
-        localStorage.clear();
+        cookies.remove('token');
+        cookies.remove('email');
+        cookies.remove('user_id');
+        cookies.remove('nickname');
+        cookies.remove('avatar');
         navigate('/');
     };
 

--- a/webapp/src/helpers/Messagerie.tsx
+++ b/webapp/src/helpers/Messagerie.tsx
@@ -2,15 +2,18 @@ import Config from "../config/Config";
 import axios from 'axios';
 import { MessagerieInterface } from "../interfaces/messagerie";
 import { toast } from "react-toastify";
+import Cookies from 'universal-cookie';
+
+const cookies = new Cookies();
 
 const create_or_get_discussion = async (email: string) => {
     try {
         const req = await axios.post(`${Config.Api.url}/chat/`, {
             email: email,
-            from: localStorage.getItem('email')
+            from: cookies.get('email')
         }, {
             headers: {
-                token: localStorage.getItem('token'),
+                token: cookies.get('token'),
             }
         });
         return (req.data);
@@ -23,7 +26,7 @@ const send_message_to_discussion = async (chat_id: string, content: string) => {
     try {
         const req = await axios.post(`${Config.Api.url}/chat/send`, {
             chat_id: chat_id,
-            sender_id: localStorage.getItem('user_id'),
+            sender_id: cookies.get('user_id'),
             content: content,
         });
         return (req.data);
@@ -37,7 +40,7 @@ const get_message_of_discussion = async (chat_id: string) => {
     try {
         const req = await axios.get(`${Config.Api.url}/chat/${chat_id}`, {
             headers: {
-                token: localStorage.getItem('token'),
+                token: cookies.get('token'),
             }
         });
         return (req.data);
@@ -127,7 +130,7 @@ const   update_admin_list = async (chat_id: string, list_to_add: number[], list_
             chat_id: chat_id,
             list_to_add: list_to_add,
             list_to_delete: list_to_delete,
-            user_id: localStorage.getItem('user_id') ?? '',
+            user_id: cookies.get('user_id') ?? '',
         });
         return (req.data);
     } catch (e) {
@@ -191,7 +194,7 @@ const   delete_blocked_users = async (chat_id: string, blocked_row_id: string) =
         const req = await axios.post(`${Config.Api.url}/chat/public/blocked`, {
             blocked_row_id: blocked_row_id,
             chat_id: chat_id,
-            user_id: localStorage.getItem('user_id') ?? '',
+            user_id: cookies.get('user_id') ?? '',
         });
         return (req.data);
     } catch (e) {

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -8,12 +8,15 @@ import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
 import NewAppBar from './pages/Utils/NewAppBar';
+import Cookies from 'universal-cookie';
 
 const root = ReactDOM.createRoot(
     document.getElementById('root') as HTMLElement
 );
 
-axios.defaults.headers.common['Authorization'] = 'Bearer ' + window.localStorage.getItem('token');
+const cookies = new Cookies();
+
+axios.defaults.headers.common['Authorization'] = 'Bearer ' + cookies.get('token');
 
 root.render(
     <BrowserRouter>

--- a/webapp/src/pages/Bonus/components/End.tsx
+++ b/webapp/src/pages/Bonus/components/End.tsx
@@ -1,8 +1,11 @@
 import { Button, Typography } from "@mui/material";
 import React from "react";
 import Helpers from "../../../helpers/Helpers";
+import Cookies from 'universal-cookie';
 
 export const End = ( props: { scoreOne: number, scoreTwo: number, player: number, nickname: string, opp_nickname: string  } ) => {
+
+    const cookies = new Cookies();
 
     return (
         <React.Fragment>
@@ -26,7 +29,7 @@ export const End = ( props: { scoreOne: number, scoreTwo: number, player: number
                 size="large"
                 sx={{ ml:'730px', }}
                 href='/home'
-                onClick={() => Helpers.Users.updateStatus(localStorage.getItem('nickname')!, 'online')}
+                onClick={() => Helpers.Users.updateStatus(cookies.get('nickname')!, 'online')}
             >
 				Menu
             </Button>

--- a/webapp/src/pages/Friends/customer/friend-list.js
+++ b/webapp/src/pages/Friends/customer/friend-list.js
@@ -3,10 +3,12 @@ import { Avatar, Box, Card, Button, Table, TableBody, TableCell, TableHead, Tabl
 import Helpers from '../../../helpers/Helpers';
 import { useNavigate } from 'react-router-dom';
 import { useState} from 'react';
+import Cookies from 'universal-cookie';
 
 const AddFriendButton = ( { friendUser }) => {
 
     const [friendStatus, setFriendStatus] = useState('initial');
+    const cookies = new Cookies();
 
     Helpers.Friends.getFriendRequestStatus(friendUser).then(res => {
         setFriendStatus(res);});
@@ -44,7 +46,7 @@ const AddFriendButton = ( { friendUser }) => {
             <Box>
                 <Button
                     onClick={() => {
-                        Helpers.Friends.sendFriendRequest(friendUser, localStorage.getItem('nickname'));
+                        Helpers.Friends.sendFriendRequest(friendUser, cookies.get('nickname'));
                         setFriendStatus('pending');
                     }}
                     size="small"

--- a/webapp/src/pages/Friends/customer/friend-requests-sent.js
+++ b/webapp/src/pages/Friends/customer/friend-requests-sent.js
@@ -3,16 +3,19 @@ import { Box } from "@mui/system";
 import PerfectScrollbar from 'react-perfect-scrollbar';
 import Helpers from '../../../helpers/Helpers';
 import { useState } from "react";
+import Cookies from 'universal-cookie';
 
 export const RequestSentButton = ({otherUser}) => {
     const [cancelled, setCancelled] = useState(0);
+    const cookies = new Cookies();
+
     return (cancelled === 0 ?
         <Button sx={{ ml: 2 }}
             size="small"
             variant="contained"
             color="error"
             onClick={() => {
-                Helpers.Friends.acceptFriendRequest(localStorage.getItem('nickname'), otherUser, false);
+                Helpers.Friends.acceptFriendRequest(cookies.get('nickname'), otherUser, false);
                 setCancelled(1);
             }}>
                 Cancel

--- a/webapp/src/pages/Friends/customer/friend-requests.js
+++ b/webapp/src/pages/Friends/customer/friend-requests.js
@@ -4,9 +4,12 @@ import DoneIcon from '@mui/icons-material/Done';
 import ClearIcon from '@mui/icons-material/Clear';
 import Helpers from '../../../helpers/Helpers';
 import { useState } from 'react';
+import Cookies from 'universal-cookie';
 
 export const RequestButton = ({otherUser}) => {
     const [requestStatus, setRequestStatus] = useState('');
+    const cookies = new Cookies();
+
     Helpers.Friends.getFriendRequestStatus(otherUser).then(res => {
         setRequestStatus(res);});
     switch (requestStatus) {
@@ -32,13 +35,13 @@ export const RequestButton = ({otherUser}) => {
         return(
             <Box>
                 <IconButton sx={{ml: 2}} onClick={() => {
-                    Helpers.Friends.acceptFriendRequest(otherUser, localStorage.getItem('nickname'), true);
+                    Helpers.Friends.acceptFriendRequest(otherUser, cookies.get('nickname'), true);
                     setRequestStatus('accepted');
                 }}>
                     <DoneIcon/>
                 </IconButton>
                 <IconButton onClick={() => {
-                    Helpers.Friends.acceptFriendRequest(otherUser, localStorage.getItem('nickname'), false);
+                    Helpers.Friends.acceptFriendRequest(otherUser, cookies.get('nickname'), false);
                     setRequestStatus('cancelled');
                 }}>
                     <ClearIcon/>

--- a/webapp/src/pages/Login/EmailLogin.tsx
+++ b/webapp/src/pages/Login/EmailLogin.tsx
@@ -4,12 +4,14 @@ import { useNavigate } from 'react-router-dom';
 import { TextField, Button, Typography } from '@mui/material';
 import { toast } from 'react-toastify';
 import './EmailLogin.scss';
+import Cookies from 'universal-cookie';
 
 function EmailLogin() {
 
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
     const navigate = useNavigate();
+    const cookies = new Cookies();
 
     const handleSubmit = async(e: { preventDefault: any }): Promise<void> => {
         e.preventDefault();
@@ -17,10 +19,10 @@ function EmailLogin() {
         if (req){
             setEmail('');
             setPassword('');
-            localStorage.setItem('token', req.token);
-            localStorage.setItem('email', req.email);
-            localStorage.setItem('user_id', req.user_id);
-            localStorage.setItem('nickname', req.nickname);
+            cookies.set('token', req.token);
+            cookies.set('email', req.email);
+            cookies.set('user_id', req.user_id);
+            cookies.set('nickname', req.nickname);
             navigate('/home');
             Helpers.Users.updateStatus(req.nickname, 'online');
         } else {

--- a/webapp/src/pages/Login/Login.tsx
+++ b/webapp/src/pages/Login/Login.tsx
@@ -4,23 +4,24 @@ import { useEffect } from 'react';
 import Helpers from '../../helpers/Helpers';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
-
+import Cookies from 'universal-cookie';
 
 function Login() {
     const code_url = `https://api.intra.42.fr/oauth/authorize?client_id=${process.env.REACT_APP_CLIENT_ID}&redirect_uri=${process.env.REACT_APP_REDIRECT_URI}&response_type=code`;
     const search = useLocation().search;
     const code = new URLSearchParams(search).get('code');
     const navigate = useNavigate();
+    const cookies = new Cookies();
 
     const loggUser = async(): Promise<void> => {
         if (code){
             const req = await Helpers.Users.login(code);
             if (req) {
-                window.localStorage.setItem('token', req.token);
-                window.localStorage.setItem('email', req.email);
-                window.localStorage.setItem('user_id', req.user_id);
-                window.localStorage.setItem('nickname', req.nickname);
-                window.localStorage.setItem('avatar', req.avatar);
+                cookies.set('token', req.token);
+                cookies.set('email', req.email);
+                cookies.set('user_id', req.user_id);
+                cookies.set('nickname', req.nickname);
+                cookies.set('avatar', req.avatar);
                 //check if user has two factor auth
                 const user = await Helpers.Users.me();
                 if (user?.two_factor_enabled === true)

--- a/webapp/src/pages/Pong/components/End.tsx
+++ b/webapp/src/pages/Pong/components/End.tsx
@@ -1,8 +1,11 @@
 import { Button, Typography } from "@mui/material";
 import React from "react";
 import Helpers from "../../../helpers/Helpers";
+import Cookies from 'universal-cookie';
 
 export const End = ( props: { scoreOne: number; scoreTwo: number } ) => {
+
+    const cookies = new Cookies();
 
     return (
         <React.Fragment>
@@ -26,7 +29,7 @@ export const End = ( props: { scoreOne: number; scoreTwo: number } ) => {
                 size="large"
                 sx={{ ml:'730px', }}
                 href='/play'
-                onClick={() => Helpers.Users.updateStatus(localStorage.getItem('nickname')!, 'online')}
+                onClick={() => Helpers.Users.updateStatus(cookies.get('nickname')!, 'online')}
             >
 				Menu
             </Button>

--- a/webapp/src/pages/Profile/Profile.tsx
+++ b/webapp/src/pages/Profile/Profile.tsx
@@ -11,6 +11,7 @@ import DoneIcon from '@mui/icons-material/Done';
 import ClearIcon from '@mui/icons-material/Clear';
 import GroupIcon from '@mui/icons-material/Group';
 import { toast } from 'react-toastify';
+import Cookies from 'universal-cookie';
 
 const Profile = () => {
     const [user, setUser] = useState({
@@ -27,6 +28,7 @@ const Profile = () => {
     const userToGet = window.location.pathname.split('/')[2];
     const [isBlocked, setIsBlocked] = useState(false);
     const navigate = useNavigate();
+    const cookies = new Cookies();
 
     const statusMap = new Map([
         ['online', 'success'],
@@ -78,13 +80,13 @@ const Profile = () => {
                         { buttonText }
                     </Button>
                     <IconButton onClick={() => {
-                        Helpers.Friends.acceptFriendRequest(userToGet, localStorage.getItem('nickname')!, true);
+                        Helpers.Friends.acceptFriendRequest(userToGet, cookies.get('nickname')!, true);
                         forceUpdate();
                     }}>
                         <DoneIcon sx={{ml: 1, mb: 0.3}}/>
                     </IconButton>
                     <IconButton onClick={() => {
-                        Helpers.Friends.acceptFriendRequest(userToGet, localStorage.getItem('nickname')!, false);
+                        Helpers.Friends.acceptFriendRequest(userToGet, cookies.get('nickname')!, false);
                         forceUpdate();
                     }}>
                         <ClearIcon sx={{ml: 1, mb: 0.3}}/>
@@ -113,13 +115,13 @@ const Profile = () => {
 
     const sendFriendRequest = () => {
         setButtonText('Request sent');
-        Helpers.Friends.sendFriendRequest(user.nickname, localStorage.getItem('nickname')!);
+        Helpers.Friends.sendFriendRequest(user.nickname, cookies.get('nickname')!);
     };
     getFriendStatus();
 
     const blockUser = async() => {
         const req = await Helpers.Users.blockUser(
-            localStorage.getItem('user_id') ?? '',
+            cookies.get('user_id') ?? '',
             user?.id
         );
         if (req) {
@@ -130,7 +132,7 @@ const Profile = () => {
 
     const is_user_blocked= async(user_id_profile: string = ''): Promise<void>  => {
         const req = await Helpers.Friends.is_user_blocked(
-            localStorage.getItem('user_id') ?? '',
+            cookies.get('user_id') ?? '',
             user_id_profile,
         );
         if (req){
@@ -171,7 +173,7 @@ const Profile = () => {
                 <Typography id='nickname'>
                     { user?.nickname }
                 </Typography>
-                { user?.nickname === localStorage.getItem('nickname') ?
+                { user?.nickname === cookies.get('nickname') ?
                     <Button id='edit-button' onClick={() => navigate('/user')}>
                         Edit Profile
                     </Button>

--- a/webapp/src/pages/Spectating/components/End.tsx
+++ b/webapp/src/pages/Spectating/components/End.tsx
@@ -1,8 +1,10 @@
 import { Button, Typography } from "@mui/material";
 import React from "react";
 import Helpers from "../../../helpers/Helpers";
+import Cookies from 'universal-cookie';
 
 export const End = ( props: { scoreOne: number, scoreTwo: number, player: number, nickname: string, opp_nickname: string  } ) => {
+    const cookies = new Cookies();
 
     return (
         <React.Fragment>
@@ -26,7 +28,7 @@ export const End = ( props: { scoreOne: number, scoreTwo: number, player: number
                 size="large"
                 sx={{ ml:'730px', }}
                 href='/home'
-                onClick={() => Helpers.Users.updateStatus(localStorage.getItem('nickname')!, 'online')}
+                onClick={() => Helpers.Users.updateStatus(cookies.get('nickname')!, 'online')}
             >
 				Menu
             </Button>

--- a/webapp/src/pages/TwoFactor/TwoFactorAuth.tsx
+++ b/webapp/src/pages/TwoFactor/TwoFactorAuth.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from 'react-router-dom';
 import Config from "../../config/Config";
 import Helpers from "../../helpers/Helpers";
+import Cookies from 'universal-cookie';
 
 //update status to online
 const TwoFactorAuth = () => {
@@ -22,6 +23,7 @@ const TwoFactorAuth = () => {
     const [wrongCode, setWrongCode] = useState<boolean>(false);
 
     const navigate = useNavigate();
+    const cookies = new Cookies();
 
     const generateQr = async () => {
         try {
@@ -52,7 +54,7 @@ const TwoFactorAuth = () => {
                 id_42: user.id_42,
                 token: req.data.access_token,
             });
-            window.localStorage.setItem('token', req.data.access_token);
+            cookies.set('token', req.data.access_token);
             axios.defaults.headers.common['Authorization'] = 'Bearer ' + req?.data?.token;
             navigate('/home');
         } catch (e) {

--- a/webapp/src/pages/User/components/AccountDetails.tsx
+++ b/webapp/src/pages/User/components/AccountDetails.tsx
@@ -20,6 +20,7 @@ import {
 } from '@mui/material';
 import Helpers from '../../../helpers/Helpers';
 import { useNavigate } from 'react-router-dom';
+import Cookies from 'universal-cookie';
 
 export const AccountProfileDetails = (props:any) => {
 
@@ -40,6 +41,7 @@ export const AccountProfileDetails = (props:any) => {
     });
 
 	const navigate = useNavigate();
+    const cookies = new Cookies();
 
     const [error, setError] = useState<boolean>(false);
     const [message, setMessage] = useState<string>('');
@@ -103,7 +105,11 @@ export const AccountProfileDetails = (props:any) => {
 		{
 			setCheck(!check);
 			Helpers.Users.toggleTwoFactor(false, user.id_42).then((res) => {console.log(res);});
-            localStorage.clear();
+            cookies.remove('token');
+            cookies.remove('email');
+            cookies.remove('user_id');
+            cookies.remove('nickname');
+            cookies.remove('avatar');
 		    navigate('/');
 		}
 	};

--- a/webapp/src/pages/Utils/NewAppBar.tsx
+++ b/webapp/src/pages/Utils/NewAppBar.tsx
@@ -16,6 +16,7 @@ import { useNavigate } from 'react-router-dom';
 import { useState, useEffect, Fragment } from 'react';
 import MainListItems from '../Utils/listItems';
 import { Box } from '@mui/material';
+import Cookies from 'universal-cookie';
 
 import Login from '../Login/Login';
 import EmailLogin from '../Login/EmailLogin';
@@ -98,6 +99,8 @@ const Main = styled('main', { shouldForwardProp: (prop) => prop !== 'open' })<{
 
 export default function PersistentDrawerLeft() {
     const theme = useTheme();
+    const cookies = new Cookies();
+
     const [open, setOpen] = useState(true);
     const navigate = useNavigate();
 
@@ -112,8 +115,12 @@ export default function PersistentDrawerLeft() {
     });
 
     const disconnectUser = () => {
-        Helpers.Users.updateStatus(localStorage.getItem('nickname')!, 'offline');
-        localStorage.clear();
+        Helpers.Users.updateStatus(cookies.get('nickname')!, 'offline');
+        cookies.remove('token');
+        cookies.remove('email');
+        cookies.remove('user_id');
+        cookies.remove('nickname');
+        cookies.remove('avatar');
         navigate('/');
     };
 
@@ -121,7 +128,7 @@ export default function PersistentDrawerLeft() {
         '/', '/login/email', '/oauth2-redirect', '/2fa', '/login/email/', '/oauth2-redirect/', '/2fa/', '/play/pong', '/play/plong/', '/play/bonus', '/login', '/play/spectating'].includes(window.location.pathname);
 
     const handleCloseTab = () => {
-        Helpers.Users.updateStatus(localStorage.getItem('nickname')!, 'offline');
+        Helpers.Users.updateStatus(cookies.get('nickname')!, 'offline');
     };
 
     useEffect(() => {

--- a/webapp/src/pages/chat/Chat.tsx
+++ b/webapp/src/pages/chat/Chat.tsx
@@ -5,6 +5,7 @@ import { io } from 'socket.io-client';
 import './Chat.scss';
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { MessagerieInterface } from "../../interfaces/messagerie";
+import Cookies from 'universal-cookie';
 
 const socket = io('http://localhost:5000', { transports: ['websocket'] });
 
@@ -18,6 +19,7 @@ const Chat = () => {
     const location = useLocation();
     const navigate = useNavigate();
     const { chat_id } = useParams();
+    const cookies = new Cookies();
 
     const handleSubmit = async(): Promise<void> => {
         const req = await Helpers.Messagerie.send_message_to_discussion(location?.state?.chat_id ?? '', answer);
@@ -27,7 +29,7 @@ const Chat = () => {
                 data: {
                     chat_id: location?.state?.chat_id,
                     content: answer,
-                    nickname: localStorage.getItem('nickname'),
+                    nickname: cookies.get('nickname'),
                     msg_id: req,
                 }
             });
@@ -44,7 +46,7 @@ const Chat = () => {
     const isUserAdmin = async(): Promise<void> => {
         const req = await Helpers.Messagerie.is_user_admin(
             location?.state?.chat_id,
-            localStorage.getItem('user_id') ?? ''
+            cookies.get('user_id') ?? ''
         );
         if (req) {
             setIsAdmin(true);
@@ -80,16 +82,16 @@ const Chat = () => {
             {(chatInfo && chatInfo?.type === 'private') &&
                 <div
                     id='dest-private-chat'
-                    onClick={() => navigate(`/users/${chatMembers?.find((member) => member?.nickname !== localStorage.getItem('nickname'))?.nickname}`)}
+                    onClick={() => navigate(`/users/${chatMembers?.find((member) => member?.nickname !== cookies.get('nickname'))?.nickname}`)}
                 >
                     <div id='div-avatar-private-chat'>
                         <img
                             id='avatar-dest-private-chat'
-                            src={chatMembers?.find((member) => member?.nickname !== localStorage.getItem('nickname'))?.avatar}
+                            src={chatMembers?.find((member) => member?.nickname !== cookies.get('nickname'))?.avatar}
                         />
                     </div>
                     <p id='name-dest-private-chat'>
-                        {chatMembers?.find((member) => member?.nickname !== localStorage.getItem('nickname'))?.nickname}
+                        {chatMembers?.find((member) => member?.nickname !== cookies.get('nickname'))?.nickname}
                     </p>
                 </div>
             }
@@ -109,7 +111,7 @@ const Chat = () => {
                                 id={`msg-chat-${index}`}
                                 className='chat-item'
                             >
-                                <div className={`content-message-${msg?.nickname === localStorage.getItem('nickname') ? 'right' : 'left'}`}>
+                                <div className={`content-message-${msg?.nickname === cookies.get('nickname') ? 'right' : 'left'}`}>
                                     { (msg?.content.indexOf('http://localhost:3000/play/matchmaking/') >= 0) ? (
                                         <div>
                                             Do you want to play a pong game ?&nbsp;
@@ -124,7 +126,7 @@ const Chat = () => {
                                         msg?.content
                                     )}
                                 </div>
-                                <div className={`nickname-message-${msg?.nickname === localStorage.getItem('nickname') ? 'right' : 'left'}`}>
+                                <div className={`nickname-message-${msg?.nickname === cookies.get('nickname') ? 'right' : 'left'}`}>
                                     Posted by { msg?.nickname }
                                 </div>
                             </div>

--- a/webapp/src/pages/chat/Settings.tsx
+++ b/webapp/src/pages/chat/Settings.tsx
@@ -4,10 +4,12 @@ import { useEffect, useState } from "react";
 import Helpers from "../../helpers/Helpers";
 import { toast } from "react-toastify";
 import './Settings.scss';
+import Cookies from 'universal-cookie';
 
 const Settings = () => {
 
     const { chat_id } = useParams();
+    const cookies = new Cookies();
 
     const [chatPassword, setChatPassword] = useState<string>('');
     const [allMembers, setAllMembers] = useState([]);
@@ -20,7 +22,7 @@ const Settings = () => {
         const req = await Helpers.Messagerie.update_password_chat(
             chat_id ?? '',
             chatPassword,
-            localStorage.getItem('user_id') ?? ''
+            cookies.get('user_id') ?? ''
         );
         if (req) {
             toast.success('The password for this chat has been update');
@@ -65,7 +67,7 @@ const Settings = () => {
         const req = await Helpers.Messagerie.block_user_in_public_chat(
             chat_id ?? '',
             blockUserInput,
-            localStorage.getItem('user_id') ?? '',
+            cookies.get('user_id') ?? '',
         );
         if (req){
             toast.success('User successfully blocked from the public chat');

--- a/webapp/src/pages/messagerie/Messagerie.tsx
+++ b/webapp/src/pages/messagerie/Messagerie.tsx
@@ -8,6 +8,7 @@ import './Messagerie.scss';
 import { MessagerieInterface } from "../../interfaces/messagerie";
 import { toast } from "react-toastify";
 import MoreVertIcon from '@mui/icons-material/MoreVert';
+import Cookies from 'universal-cookie';
 
 const Messaging = () => {
 
@@ -17,9 +18,10 @@ const Messaging = () => {
     const [discussionSelected, setDiscussionSelected] = useState<MessagerieInterface>();
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const navigate = useNavigate();
+    const cookies = new Cookies();
 
     const handleSubmit = async(): Promise<void> => {
-        if (destinationChatName === localStorage.getItem('email')) {
+        if (destinationChatName === cookies.get('email')) {
             alert('Error, you cannot send an message to yourself');
             return ;
         }
@@ -42,7 +44,7 @@ const Messaging = () => {
         }
         const req = await Helpers.Messagerie.create_new_public_chat(
             destinationChatName,
-            localStorage.getItem('user_id') ?? '',
+            cookies.get('user_id') ?? '',
         );
         if (req) {
             setDestinationChatName('');
@@ -63,7 +65,7 @@ const Messaging = () => {
     };
 
     const get_all_discussions = async(): Promise<void> => {
-        const data = await Helpers.Messagerie.get_all_chat_by_user_id(localStorage.getItem('user_id') ?? '');
+        const data = await Helpers.Messagerie.get_all_chat_by_user_id(cookies.get('user_id') ?? '');
         if (data) {
             setAllDiscussions(data);
         }
@@ -89,7 +91,7 @@ const Messaging = () => {
                         } else {
                             const req = await Helpers.Messagerie.leave_public_chat(
                                 discussionSelected?.id ?? '',
-                                localStorage.getItem('user_id') ?? ''
+                                cookies.get('user_id') ?? ''
                             );
                             if (req) {
                                 toast.success('Succefully left the chat');
@@ -143,7 +145,7 @@ const Messaging = () => {
                                                 if (await Helpers.Messagerie.join_chat(
                                                     discussion.id,
                                                     pass,
-                                                    localStorage.getItem('user_id') ?? ''
+                                                    cookies.get('user_id') ?? ''
                                                 )) {
                                                     navigateToChat(discussion.id);
                                                 } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3546,6 +3546,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookie@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
+  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
+
 "@types/cookie@^0.4.1":
   version "0.4.1"
   resolved "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz"
@@ -5679,7 +5684,7 @@ cookie@0.5.0:
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
-cookie@~0.4.1:
+cookie@^0.4.0, cookie@~0.4.1:
   version "0.4.2"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
@@ -14222,6 +14227,14 @@ unique-string@^2.0.0:
   integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
   dependencies:
     crypto-random-string "^2.0.0"
+
+universal-cookie@4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-4.0.4.tgz#06e8b3625bf9af049569ef97109b4bb226ad798d"
+  integrity sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==
+  dependencies:
+    "@types/cookie" "^0.3.3"
+    cookie "^0.4.0"
 
 universal-user-agent@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
Le but de cette PR est de remplacer les localStorage par des cookies, c'est plus secure. Une bonne raison est expliqué dans [ce thread](https://stackoverflow.com/questions/44133536/is-it-safe-to-store-a-jwt-in-localstorage-with-reactjs) sur stack overflow.